### PR TITLE
Smooth Rounded Corners for the Popup Window

### DIFF
--- a/Windows_and_Linux/ui/CustomPopupWindow.py
+++ b/Windows_and_Linux/ui/CustomPopupWindow.py
@@ -33,7 +33,7 @@ class CustomPopupWindow(QtWidgets.QWidget):
         main_layout.setContentsMargins(0, 0, 0, 0)
 
         # Theme background
-        self.background = ThemeBackground(self, self.app.config.get('theme', 'gradient'), is_popup=True)
+        self.background = ThemeBackground(self, self.app.config.get('theme', 'gradient'), is_popup=True, border_radius=10)
         main_layout.addWidget(self.background)
 
         # Content layout
@@ -167,16 +167,6 @@ class CustomPopupWindow(QtWidgets.QWidget):
         """
         super().showEvent(event)
         logging.debug(f'CustomPopupWindow shown. Geometry: {self.geometry()}')
-
-    def paintEvent(self, event):
-        """
-        Override the paint event to create rounded corners for the window.
-        """
-        path = QtGui.QPainterPath()
-        path.addRoundedRect(QtCore.QRectF(self.rect()), 10, 10)
-        mask = QtGui.QRegion(path.toFillPolygon().toPolygon())
-        self.setMask(mask)
-        logging.debug(f'CustomPopupWindow paint event. Mask applied. Window visible: {self.isVisible()}')
 
     def on_custom_change(self):
         """

--- a/Windows_and_Linux/ui/UIUtils.py
+++ b/Windows_and_Linux/ui/UIUtils.py
@@ -51,25 +51,39 @@ class ThemeBackground(QtWidgets.QWidget):
     """
     A custom widget that creates a background for the application based on the selected theme.
     """
-    def __init__(self, parent=None, theme='gradient', is_popup=False):
+    def __init__(self, parent=None, theme='gradient', is_popup=False, border_radius=0):
         super().__init__(parent)
         self.setAttribute(QtCore.Qt.WA_StyledBackground, True)
         self.theme = theme
         self.is_popup = is_popup
+        self.border_radius = border_radius
 
     def paintEvent(self, event):
         """
         Override the paint event to draw the background based on the selected theme.
         """
         painter = QtGui.QPainter(self)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.SmoothPixmapTransform, True)
         if self.theme == 'gradient':
             if self.is_popup:
                 background_image = QtGui.QPixmap(os.path.join(os.path.dirname(sys.argv[0]), 'background_popup_dark.png' if colorMode == 'dark' else 'background_popup.png'))
             else:
                 background_image = QtGui.QPixmap(os.path.join(os.path.dirname(sys.argv[0]), 'background_dark.png' if colorMode == 'dark' else 'background.png'))
+            # Adds a path/border using which the border radius would be drawn
+            path = QtGui.QPainterPath()
+            path.addRoundedRect(0, 0, self.width(), self.height(), self.border_radius, self.border_radius)
+            painter.setClipPath(path)
+
             painter.drawPixmap(self.rect(), background_image)
         else:
             if colorMode == 'dark':
-                painter.fillRect(self.rect(), QtGui.QColor(35, 35, 35))  # Dark mode color
+                color = QtGui.QColor(35, 35, 35)  # Dark mode color
             else:
-                painter.fillRect(self.rect(), QtGui.QColor(222, 222, 222))  # Light mode color
+                color = QtGui.QColor(222, 222, 222)  # Light mode color
+            brush = QtGui.QBrush(color)
+            painter.setBrush(brush)
+            pen = QtGui.QPen(QtGui.QColor(0, 0, 0, 0))
+            pen.setWidth(0)
+            painter.setPen(pen)
+            painter.drawRoundedRect(QtCore.QRect(0, 0, self.width(), self.height()), self.border_radius, self.border_radius)


### PR DESCRIPTION
Hi there,
The corners of the window earlier were jagged, and this patch fixes them. Earlier a mask was being applied to the whole window but masking in QT or here in PySide6 does not support antialiasing so in this patch, I have rounded the corners of the `ThemeBackground` class instead and enabling antialiasing for qpainter for smoother rounded corners.
Comparison - 
Before | After
---|---
![image](https://github.com/user-attachments/assets/e5fb5bbf-58d5-43ae-a67b-f7e028248f91) | ![image](https://github.com/user-attachments/assets/478d1929-ae6e-46d2-a44c-b8dc073c264f)

Regards

