### PR TITLE
Fix winreg import for Linux compatibility

### DIFF
--- a/Windows_and_Linux/ui/AutostartManager.py
+++ b/Windows_and_Linux/ui/AutostartManager.py
@@ -1,7 +1,8 @@
 import logging
 import sys
-import winreg
 
+if sys.platform.startswith("win32"):
+    import winreg
 
 class AutostartManager:
     """


### PR DESCRIPTION
Added a platform check to import `winreg` only on Windows. This prevents a `ModuleNotFoundError` on Linux systems during runtime.

#### Changes:

- Modified `Windows_and_Linux/ui/AutostartManager.py` to conditionally import `winreg` based on the platform.