### PR TITLE
[fix/ctrl_c_simulation] Add sleep duration before Ctrl+C for clipboard update

### DIFF
--- a/Windows_and_Linux/WritingToolApp.py
+++ b/Windows_and_Linux/WritingToolApp.py
@@ -352,6 +352,7 @@ class WritingToolApp(QtWidgets.QApplication):
             kbrd.release('c')
             kbrd.release(pykeyboard.Key.ctrl.value)
 
+        time.sleep(sleep_duration)
         press_ctrl_c()
 
         # Wait for the clipboard to update


### PR DESCRIPTION
## Type of change
Fix

## Purpose of the PR
This PR introduces a sleep duration before executing the Ctrl+C command. This is to ensure that the clipboard has sufficient time to update with the desired content, preventing issues where the copy operation might fail due to the command being issued too quickly.

## Changes overview
- src/main.py

## Issues Related
#195 