### PR TITLE
OpenAI-compatible API support fails with custom Base URL. 

### DIFF
--- a/macOS/WritingTools/Models/AI Providers/OpenAIProvider.swift
+++ b/macOS/WritingTools/Models/AI Providers/OpenAIProvider.swift
@@ -56,6 +56,11 @@ class OpenAIProvider: ObservableObject, AIProvider {
                 throw NSError(domain: "OpenAIAPI", code: -1, userInfo: [NSLocalizedDescriptionKey: "API key is missing."])
             }
             
+            // Check for custom Base URL
+            if !config.baseURL.isEmpty && config.baseURL != OpenAIConfig.defaultBaseURL {
+                return try await performCustomOpenAIRequest(systemPrompt: systemPrompt, userPrompt: userPrompt, images: images, streaming: streaming)
+            }
+            
             if aiProxyService == nil {
                 setupAIProxyService()
             }
@@ -121,6 +126,94 @@ class OpenAIProvider: ObservableObject, AIProvider {
                 throw error
             }
         }
+    
+    // MARK: - Custom Request Implementation
+    
+    private func performCustomOpenAIRequest(systemPrompt: String?, userPrompt: String, images: [Data], streaming: Bool) async throws -> String {
+        // Construct URL
+        var urlString = config.baseURL
+        if urlString.hasSuffix("/") {
+            urlString = String(urlString.dropLast())
+        }
+        // Append /chat/completions if not present (simple heuristic, can be improved)
+        if !urlString.hasSuffix("/chat/completions") {
+             urlString += "/chat/completions"
+        }
+        
+        guard let url = URL(string: urlString) else {
+            throw NSError(domain: "OpenAIAPI", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid Base URL."])
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        // Construct Body
+        var messages: [[String: Any]] = []
+        
+        if let systemPrompt = systemPrompt {
+            messages.append(["role": "system", "content": systemPrompt])
+        }
+        
+        if images.isEmpty {
+            messages.append(["role": "user", "content": userPrompt])
+        } else {
+            var content: [[String: Any]] = [
+                ["type": "text", "text": userPrompt]
+            ]
+            
+            for imageData in images {
+                let base64 = imageData.base64EncodedString()
+                content.append([
+                    "type": "image_url",
+                    "image_url": [
+                        "url": "data:image/jpeg;base64,\(base64)"
+                    ]
+                ])
+            }
+            messages.append(["role": "user", "content": content])
+        }
+        
+        let body: [String: Any] = [
+            "model": config.model,
+            "messages": messages,
+            "stream": false // Forcing non-streaming for custom providers for now to ensure compatibility
+        ]
+        
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+             throw NSError(domain: "OpenAIAPI", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid response type."])
+        }
+        
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+            print("Custom OpenAI Request Failed: \(httpResponse.statusCode) - \(errorBody)")
+            throw NSError(domain: "OpenAIAPI", code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: "API Error: \(errorBody)"])
+        }
+        
+        // Parse Response
+        struct ChatCompletionResponse: Decodable {
+            struct Choice: Decodable {
+                struct Message: Decodable {
+                    let content: String?
+                }
+                let message: Message
+            }
+            let choices: [Choice]
+        }
+        
+        do {
+            let decoded = try JSONDecoder().decode(ChatCompletionResponse.self, from: data)
+            return decoded.choices.first?.message.content ?? ""
+        } catch {
+            print("Failed to decode response: \(error)")
+             throw NSError(domain: "OpenAIAPI", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to parse API response."])
+        }
+    }
 
     
     func cancel() {


### PR DESCRIPTION
TLDR: Added custom request handling for OpenAI API with base URL support.

## Description
When configuring the OpenAI provider with a custom Base URL (e.g., for Groq or other compatible services), the application fails to successfully complete requests. This issue appears to stem from the `AIProxy` dependency, which may not correctly handle custom endpoints or the specific response formats returned by third-party providers.

## Resolution
I have implemented a fix in [OpenAIProvider.swift](file:///Users/aurelius/Documents/Projects/WritingTools/macOS/WritingTools/Models/AI%20Providers/OpenAIProvider.swift) to improve compatibility:

1.  **Detection**: The provider now checks if a custom `baseURL` is set (different from the default OpenAI URL).
2.  **Direct Fallback**: When a custom URL is detected, the app bypasses `AIProxy` and uses a direct `URLSession` implementation to send the request.
3.  **Verification**: This has been tested and verified to work correctly with Groq (`https://api.groq.com/openai/v1`) using the `openai/gpt-oss-120b` model.

This ensures that the application can support any standard OpenAI-compatible provider without being limited by the proxy service's constraints.
