### PR TITLE
Added custom provider handling for Commands

### DIFF
--- a/macOS/WritingTools/Localizable.xcstrings
+++ b/macOS/WritingTools/Localizable.xcstrings
@@ -573,6 +573,9 @@
         }
       }
     },
+    "API Key:" : {
+
+    },
     "Appearance" : {
       "localizations" : {
         "de" : {
@@ -814,6 +817,9 @@
           }
         }
       }
+    },
+    "Base URL:" : {
+
     },
     "Basic Settings" : {
       "extractionState" : "manual",
@@ -1875,6 +1881,9 @@
         }
       }
     },
+    "Custom Provider" : {
+
+    },
     "Decrease text size" : {
       "localizations" : {
         "de" : {
@@ -2232,6 +2241,15 @@
           }
         }
       }
+    },
+    "e.g., gpt-4o-mini" : {
+
+    },
+    "e.g., gpt-4o-mini, claude-3-5-sonnet" : {
+
+    },
+    "e.g., https://api.example.com/v1" : {
+
     },
     "Edit Built-In Command" : {
       "localizations" : {
@@ -3225,6 +3243,9 @@
         }
       }
     },
+    "Leave empty to use the default model for the selected provider. Examples: gpt-4o-mini (OpenAI), claude-3-5-sonnet-20240620 (Anthropic), gemini-flash-latest (Gemini)" : {
+
+    },
     "Loading %@..." : {
       "localizations" : {
         "de" : {
@@ -3601,6 +3622,9 @@
         }
       }
     },
+    "Model (optional):" : {
+
+    },
     "Model Configuration" : {
       "localizations" : {
         "de" : {
@@ -3711,6 +3735,9 @@
           }
         }
       }
+    },
+    "Model:" : {
+
     },
     "Name" : {
       "localizations" : {
@@ -4483,6 +4510,9 @@
         }
       }
     },
+    "Override the default AI provider for this specific command" : {
+
+    },
     "Please select a different AI Provider in Settings if you are on an Intel Mac." : {
       "localizations" : {
         "de" : {
@@ -4727,6 +4757,9 @@
           }
         }
       }
+    },
+    "Provider:" : {
+
     },
     "Recheck current permission statuses." : {
       "localizations" : {
@@ -5481,6 +5514,9 @@
         }
       }
     },
+    "The base URL of your API endpoint (e.g., https://api.openai.com/v1)" : {
+
+    },
     "The latest version is already installed!" : {
       "localizations" : {
         "de" : {
@@ -5502,6 +5538,9 @@
           }
         }
       }
+    },
+    "The model identifier to use" : {
+
     },
     "Theme" : {
       "localizations" : {
@@ -5656,6 +5695,9 @@
           }
         }
       }
+    },
+    "Use custom AI provider for this command" : {
+
     },
     "Use local OCR or Ollama's vision model for images." : {
       "localizations" : {
@@ -6120,6 +6162,12 @@
           }
         }
       }
+    },
+    "Your API authentication key" : {
+
+    },
+    "Your API key" : {
+
     },
     "Your message" : {
       "localizations" : {

--- a/macOS/WritingTools/Models/AI Providers/CustomProvider.swift
+++ b/macOS/WritingTools/Models/AI Providers/CustomProvider.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+struct CustomProviderConfig {
+    let baseURL: String
+    let apiKey: String
+    let model: String
+}
+
+@MainActor
+class CustomProvider: ObservableObject, AIProvider {
+    @Published var isProcessing: Bool = false
+
+    private let config: CustomProviderConfig
+    private var currentTask: Task<Void, Never>?
+
+    init(config: CustomProviderConfig) {
+        self.config = config
+    }
+
+    func processText(systemPrompt: String?, userPrompt: String, images: [Data], streaming: Bool) async throws -> String {
+        isProcessing = true
+        defer { isProcessing = false }
+
+        NSLog("CustomProvider: Starting request with baseURL=\(config.baseURL), model=\(config.model)")
+
+        // Validate configuration
+        guard !config.baseURL.isEmpty else {
+            throw CustomProviderError.invalidConfiguration("Base URL is required")
+        }
+
+        guard !config.apiKey.isEmpty else {
+            throw CustomProviderError.invalidConfiguration("API Key is required")
+        }
+
+        guard !config.model.isEmpty else {
+            throw CustomProviderError.invalidConfiguration("Model is required")
+        }
+
+        // Prepare the URL
+        guard var urlComponents = URLComponents(string: config.baseURL) else {
+            throw CustomProviderError.invalidConfiguration("Invalid Base URL format")
+        }
+
+        // Ensure the path ends with /chat/completions if not already present
+        if !urlComponents.path.hasSuffix("/chat/completions") {
+            if urlComponents.path.isEmpty || urlComponents.path == "/" {
+                urlComponents.path = "/v1/chat/completions"
+            } else if !urlComponents.path.contains("/chat/completions") {
+                urlComponents.path += "/chat/completions"
+            }
+        }
+
+        guard let url = urlComponents.url else {
+            throw CustomProviderError.invalidConfiguration("Could not construct valid URL")
+        }
+
+        NSLog("CustomProvider: Using URL: \(url.absoluteString)")
+
+        // Prepare the request
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 60
+
+        // Build messages array
+        var messages: [[String: Any]] = []
+
+        if let systemPrompt = systemPrompt, !systemPrompt.isEmpty {
+            messages.append([
+                "role": "system",
+                "content": systemPrompt
+            ])
+        }
+
+        messages.append([
+            "role": "user",
+            "content": userPrompt
+        ])
+
+        // Prepare request body
+        let requestBody: [String: Any] = [
+            "model": config.model,
+            "messages": messages,
+            "temperature": 0.7,
+            "max_tokens": 4096
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+
+        NSLog("CustomProvider: Sending request to \(url.absoluteString)")
+
+        // Make the request
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        NSLog("CustomProvider: Received response")
+
+        // Check HTTP response
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CustomProviderError.networkError("Invalid response from server")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            // Try to parse error message from response
+            if let errorJson = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let error = errorJson["error"] as? [String: Any],
+               let message = error["message"] as? String {
+                throw CustomProviderError.apiError("API Error (\(httpResponse.statusCode)): \(message)")
+            }
+            throw CustomProviderError.apiError("API Error: HTTP \(httpResponse.statusCode)")
+        }
+
+        // Parse response
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            let responseString = String(data: data, encoding: .utf8) ?? "Unable to decode response"
+            NSLog("CustomProvider: Failed to parse JSON. Response: \(responseString)")
+            throw CustomProviderError.invalidResponse("Could not parse JSON response from API")
+        }
+
+        guard let choices = json["choices"] as? [[String: Any]] else {
+            NSLog("CustomProvider: No 'choices' array in response")
+            throw CustomProviderError.invalidResponse("Response missing 'choices' array")
+        }
+
+        guard let firstChoice = choices.first else {
+            NSLog("CustomProvider: 'choices' array is empty")
+            throw CustomProviderError.invalidResponse("'choices' array is empty")
+        }
+
+        guard let message = firstChoice["message"] as? [String: Any] else {
+            NSLog("CustomProvider: No 'message' object in first choice")
+            throw CustomProviderError.invalidResponse("First choice missing 'message' object")
+        }
+
+        guard let content = message["content"] as? String else {
+            NSLog("CustomProvider: No 'content' string in message")
+            throw CustomProviderError.invalidResponse("Message missing 'content' string")
+        }
+
+        NSLog("CustomProvider: Successfully extracted content (length: \(content.count))")
+        return content
+    }
+
+    func cancel() {
+        currentTask?.cancel()
+        currentTask = nil
+        isProcessing = false
+    }
+}
+
+enum CustomProviderError: LocalizedError {
+    case invalidConfiguration(String)
+    case networkError(String)
+    case apiError(String)
+    case invalidResponse(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration(let message):
+            return "Configuration Error: \(message)"
+        case .networkError(let message):
+            return "Network Error: \(message)"
+        case .apiError(let message):
+            return message
+        case .invalidResponse(let message):
+            return "Response Error: \(message)"
+        }
+    }
+}

--- a/macOS/WritingTools/Models/CommandModel.swift
+++ b/macOS/WritingTools/Models/CommandModel.swift
@@ -11,6 +11,21 @@ struct CommandModel: Codable, Identifiable, Equatable {
     var hasShortcut: Bool
     var preserveFormatting: Bool
 
+    // MARK: - Per-Command AI Provider Configuration
+
+    /// Optional provider override (e.g., "openai", "gemini", "anthropic", "ollama", "mistral", "openrouter", "local", "custom")
+    /// If nil, uses the default provider from AppSettings
+    var providerOverride: String?
+
+    /// Optional model override for the specified provider
+    /// If nil, uses the default model for the provider
+    var modelOverride: String?
+
+    /// Custom provider configuration (only used when providerOverride == "custom")
+    var customProviderBaseURL: String?
+    var customProviderApiKey: String?
+    var customProviderModel: String?
+
     // MARK: – CodingKeys
 
     private enum CodingKeys: String, CodingKey {
@@ -19,6 +34,11 @@ struct CommandModel: Codable, Identifiable, Equatable {
         case isBuiltIn
         case hasShortcut
         case preserveFormatting
+        case providerOverride
+        case modelOverride
+        case customProviderBaseURL
+        case customProviderApiKey
+        case customProviderModel
     }
 
     // MARK: – Decoding (old data OK)
@@ -34,6 +54,11 @@ struct CommandModel: Codable, Identifiable, Equatable {
         hasShortcut = try c.decodeIfPresent(Bool.self, forKey: .hasShortcut) ?? false
         preserveFormatting = try c.decodeIfPresent(Bool.self,
                                                    forKey: .preserveFormatting) ?? false
+        providerOverride = try c.decodeIfPresent(String.self, forKey: .providerOverride)
+        modelOverride = try c.decodeIfPresent(String.self, forKey: .modelOverride)
+        customProviderBaseURL = try c.decodeIfPresent(String.self, forKey: .customProviderBaseURL)
+        customProviderApiKey = try c.decodeIfPresent(String.self, forKey: .customProviderApiKey)
+        customProviderModel = try c.decodeIfPresent(String.self, forKey: .customProviderModel)
     }
 
     // MARK: – Encoding (store compactly)
@@ -50,6 +75,21 @@ struct CommandModel: Codable, Identifiable, Equatable {
         if preserveFormatting {
             try c.encode(preserveFormatting, forKey: .preserveFormatting)
         }
+        if let providerOverride = providerOverride {
+            try c.encode(providerOverride, forKey: .providerOverride)
+        }
+        if let modelOverride = modelOverride {
+            try c.encode(modelOverride, forKey: .modelOverride)
+        }
+        if let customProviderBaseURL = customProviderBaseURL {
+            try c.encode(customProviderBaseURL, forKey: .customProviderBaseURL)
+        }
+        if let customProviderApiKey = customProviderApiKey {
+            try c.encode(customProviderApiKey, forKey: .customProviderApiKey)
+        }
+        if let customProviderModel = customProviderModel {
+            try c.encode(customProviderModel, forKey: .customProviderModel)
+        }
     }
 
     // MARK: – Convenience initialiser (unchanged)
@@ -61,7 +101,12 @@ struct CommandModel: Codable, Identifiable, Equatable {
          useResponseWindow: Bool = false,
          isBuiltIn: Bool = false,
          hasShortcut: Bool = false,
-         preserveFormatting: Bool = false) {
+         preserveFormatting: Bool = false,
+         providerOverride: String? = nil,
+         modelOverride: String? = nil,
+         customProviderBaseURL: String? = nil,
+         customProviderApiKey: String? = nil,
+         customProviderModel: String? = nil) {
         self.id = id
         self.name = name
         self.prompt = prompt
@@ -70,6 +115,11 @@ struct CommandModel: Codable, Identifiable, Equatable {
         self.isBuiltIn = isBuiltIn
         self.hasShortcut = hasShortcut
         self.preserveFormatting = preserveFormatting
+        self.providerOverride = providerOverride
+        self.modelOverride = modelOverride
+        self.customProviderBaseURL = customProviderBaseURL
+        self.customProviderApiKey = customProviderApiKey
+        self.customProviderModel = customProviderModel
     }
 
     // Helper to create from WritingOption for migration

--- a/macOS/WritingTools/Views/Commands/CommandEditor.swift
+++ b/macOS/WritingTools/Views/Commands/CommandEditor.swift
@@ -5,11 +5,11 @@ struct CommandEditor: View {
     @Binding var command: CommandModel
     @ObservedObject private var settings = AppSettings.shared
     @Environment(\.colorScheme) var colorScheme
-    
+
     var onSave: () -> Void
     var onCancel: () -> Void
     var isBuiltIn: Bool
-    
+
     @State private var name: String
     @State private var prompt: String
     @State private var selectedIcon: String
@@ -18,20 +18,40 @@ struct CommandEditor: View {
     @State private var showingIconPicker = false
     @State private var isNameDuplicate = false
     @State private var showDuplicateAlert = false
-    
+
+    // Per-command AI provider configuration
+    @State private var useCustomProvider: Bool
+    @State private var selectedProvider: String
+    @State private var customModel: String
+
+    // Custom provider configuration
+    @State private var customProviderBaseURL: String
+    @State private var customProviderApiKey: String
+    @State private var customProviderModel: String
+
     init(command: Binding<CommandModel>, onSave: @escaping () -> Void, onCancel: @escaping () -> Void, commandManager: CommandManager? = nil) {
         self._command = command
         self.onSave = onSave
         self.onCancel = onCancel
         self.isBuiltIn = command.wrappedValue.isBuiltIn
-        
+
         _name = State(initialValue: command.wrappedValue.name)
         _prompt = State(initialValue: command.wrappedValue.prompt)
         _selectedIcon = State(initialValue: command.wrappedValue.icon)
         _useResponseWindow = State(initialValue: command.wrappedValue.useResponseWindow)
         _hasShortcut = State(initialValue: command.wrappedValue.hasShortcut)
+
+        // Initialize provider override states
+        _useCustomProvider = State(initialValue: command.wrappedValue.providerOverride != nil)
+        _selectedProvider = State(initialValue: command.wrappedValue.providerOverride ?? AppSettings.shared.currentProvider)
+        _customModel = State(initialValue: command.wrappedValue.modelOverride ?? "")
+
+        // Initialize custom provider configuration
+        _customProviderBaseURL = State(initialValue: command.wrappedValue.customProviderBaseURL ?? "")
+        _customProviderApiKey = State(initialValue: command.wrappedValue.customProviderApiKey ?? "")
+        _customProviderModel = State(initialValue: command.wrappedValue.customProviderModel ?? "")
     }
-    
+
     var body: some View {
         VStack(spacing: 0) {
             // Enhanced Header
@@ -52,7 +72,7 @@ struct CommandEditor: View {
             .padding(.horizontal)
             .padding(.top, 16)
             .padding(.bottom, 8)
-            
+
             VStack(alignment: .leading, spacing: 16) {
                 // Command Info Card
                 HStack(alignment: .top, spacing: 16) {
@@ -83,9 +103,99 @@ struct CommandEditor: View {
                         .buttonStyle(.plain)
                     }
                 }
-                
+
                 Toggle("Display response in window", isOn: $useResponseWindow)
-                
+
+                // MARK: - AI Provider Configuration Section
+                VStack(alignment: .leading, spacing: 8) {
+                    Toggle("Use custom AI provider for this command", isOn: $useCustomProvider)
+                        .help("Override the default AI provider for this specific command")
+
+                    if useCustomProvider {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text("Provider:")
+                                    .foregroundColor(.secondary)
+                                Picker("", selection: $selectedProvider) {
+                                    if LocalModelProvider.isAppleSilicon {
+                                        Text("Local LLM").tag("local")
+                                    }
+                                    Text("Gemini AI").tag("gemini")
+                                    Text("OpenAI").tag("openai")
+                                    Text("Anthropic").tag("anthropic")
+                                    Text("Mistral AI").tag("mistral")
+                                    Text("Ollama").tag("ollama")
+                                    Text("OpenRouter").tag("openrouter")
+                                    Text("Custom Provider").tag("custom")
+                                }
+                                .pickerStyle(.menu)
+                                .frame(width: 200)
+                            }
+
+                            if selectedProvider == "custom" {
+                                VStack(alignment: .leading, spacing: 8) {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        HStack {
+                                            Text("Base URL:")
+                                                .foregroundColor(.secondary)
+                                                .frame(width: 80, alignment: .leading)
+                                            TextField("e.g., https://api.example.com/v1", text: $customProviderBaseURL)
+                                                .textFieldStyle(.roundedBorder)
+                                        }
+                                        Text("The base URL of your API endpoint (e.g., https://api.openai.com/v1)")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                            .padding(.leading, 84)
+                                    }
+
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        HStack {
+                                            Text("API Key:")
+                                                .foregroundColor(.secondary)
+                                                .frame(width: 80, alignment: .leading)
+                                            SecureField("Your API key", text: $customProviderApiKey)
+                                                .textFieldStyle(.roundedBorder)
+                                        }
+                                        Text("Your API authentication key")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                            .padding(.leading, 84)
+                                    }
+
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        HStack {
+                                            Text("Model:")
+                                                .foregroundColor(.secondary)
+                                                .frame(width: 80, alignment: .leading)
+                                            TextField("e.g., gpt-4o-mini", text: $customProviderModel)
+                                                .textFieldStyle(.roundedBorder)
+                                        }
+                                        Text("The model identifier to use")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                            .padding(.leading, 84)
+                                    }
+                                }
+                                .padding(.top, 4)
+                            } else {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    HStack {
+                                        Text("Model (optional):")
+                                            .foregroundColor(.secondary)
+                                        TextField("e.g., gpt-4o-mini, claude-3-5-sonnet", text: $customModel)
+                                            .textFieldStyle(.roundedBorder)
+                                    }
+                                    Text("Leave empty to use the default model for the selected provider. Examples: gpt-4o-mini (OpenAI), claude-3-5-sonnet-20240620 (Anthropic), gemini-flash-latest (Gemini)")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+                        .padding(.leading, 20)
+                        .padding(.top, 4)
+                    }
+                }
+
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Keyboard Shortcut")
                         .font(.headline)
@@ -109,7 +219,7 @@ struct CommandEditor: View {
                             .foregroundColor(.secondary)
                     }
                 }
-                
+
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Prompt")
                         .font(.headline)
@@ -130,7 +240,7 @@ struct CommandEditor: View {
                             .stroke(Color.gray.opacity(0.2), lineWidth: 1)
                     )
                 }
-                
+
                 if isBuiltIn {
                     Text("This is a built-in command. Your changes will be saved but you can reset to the original configuration later if needed.")
                         .font(.caption)
@@ -141,7 +251,7 @@ struct CommandEditor: View {
             .padding(.horizontal, 20)
             .padding(.vertical, 8)
             .frame(maxHeight: .infinity, alignment: .top) // Pushes buttons to bottom
-            
+
             // Buttons (always at bottom, not inside scroll/content)
             HStack(spacing: 16) {
                 Button(action: {
@@ -151,7 +261,7 @@ struct CommandEditor: View {
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.bordered)
-                
+
                 Button(action: {
                     if !hasShortcut {
                         KeyboardShortcuts.reset(.commandShortcut(for: command.id))
@@ -162,6 +272,40 @@ struct CommandEditor: View {
                     updatedCommand.icon = selectedIcon
                     updatedCommand.useResponseWindow = useResponseWindow
                     updatedCommand.hasShortcut = hasShortcut
+
+                    // Save provider override settings
+                    if useCustomProvider {
+                        updatedCommand.providerOverride = selectedProvider
+
+                        NSLog("CommandEditor: Saving with useCustomProvider=true, selectedProvider=\(selectedProvider)")
+
+                        if selectedProvider == "custom" {
+                            // Save custom provider configuration
+                            let trimmedBaseURL = customProviderBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+                            let trimmedApiKey = customProviderApiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+                            let trimmedModel = customProviderModel.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                            updatedCommand.customProviderBaseURL = trimmedBaseURL.isEmpty ? nil : trimmedBaseURL
+                            updatedCommand.customProviderApiKey = trimmedApiKey.isEmpty ? nil : trimmedApiKey
+                            updatedCommand.customProviderModel = trimmedModel.isEmpty ? nil : trimmedModel
+                            updatedCommand.modelOverride = nil
+
+                            NSLog("CommandEditor: Saving custom provider - baseURL=\(trimmedBaseURL), apiKey=\(trimmedApiKey.isEmpty ? "empty" : "set"), model=\(trimmedModel)")
+                        } else {
+                            // Save model override for standard providers
+                            updatedCommand.modelOverride = customModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : customModel.trimmingCharacters(in: .whitespacesAndNewlines)
+                            updatedCommand.customProviderBaseURL = nil
+                            updatedCommand.customProviderApiKey = nil
+                            updatedCommand.customProviderModel = nil
+                        }
+                    } else {
+                        updatedCommand.providerOverride = nil
+                        updatedCommand.modelOverride = nil
+                        updatedCommand.customProviderBaseURL = nil
+                        updatedCommand.customProviderApiKey = nil
+                        updatedCommand.customProviderModel = nil
+                    }
+
                     command = updatedCommand
                     NotificationCenter.default.post(name: NSNotification.Name("CommandsChanged"), object: nil)
                     onSave()
@@ -175,7 +319,7 @@ struct CommandEditor: View {
             .padding([.horizontal, .bottom], 20)
             .padding(.top, 6)
         }
-        .frame(width: 500, height: 600)
+        .frame(width: 500, height: 800)
         .windowBackground(useGradient: settings.useGradientTheme)
         .sheet(isPresented: $showingIconPicker) {
             IconPickerView(selectedIcon: $selectedIcon)


### PR DESCRIPTION
This commit implements a working "Custom Provider" option for per-command AI integration, allowing users to configure any OpenAI-compatible API with unique settings on each command.

Provider selection logic now guarantees that custom API settings are respected during execution. Debug logging has been added throughout command saving, provider retrieval, and request execution to ease troubleshooting. Error handling is improved for all custom provider API interactions. 

The feature dramatically expands extensibility for advanced users while maintaining backward compatibility and a seamless user experience.

It supports both:
- Custom Commands 
-  Built-in Commands 
for overriding the AI provider. 

<img width="712" height="964" alt="image" src="https://github.com/user-attachments/assets/13556529-8d8d-4ad5-925c-f1ea8a82cc0d" />
