### PR TITLE
Fix System Settings privacy URLs in the macOS app

### DIFF
--- a/macOS/WritingTools/Views/Onboarding/OnboardingView.swift
+++ b/macOS/WritingTools/Views/Onboarding/OnboardingView.swift
@@ -150,6 +150,9 @@ import ApplicationServices
     .onAppear {
       refreshPermissionStatuses()
     }
+    .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+      refreshPermissionStatuses()
+    }
   }
 
   private func refreshPermissionStatuses() {
@@ -159,12 +162,7 @@ import ApplicationServices
   }
 
   private func openPrivacyPane(anchor: String) {
-    if let url = URL(
-      string:
-        "x-apple.systemsettings:com.apple.settings.PrivacySecurity.extension?\(anchor)"
-    ) {
-      NSWorkspace.shared.open(url)
-    }
+    SystemSettingsOpener.openPrivacyPane(anchor: anchor)
   }
 
   private func openCommandsManager() {

--- a/macOS/WritingTools/Views/Onboarding/Views/OnboardingPermissionsStep.swift
+++ b/macOS/WritingTools/Views/Onboarding/Views/OnboardingPermissionsStep.swift
@@ -9,6 +9,29 @@ import SwiftUI
 import ApplicationServices
 import CoreGraphics
 
+enum SystemSettingsOpener {
+  @MainActor
+  static func openPrivacyPane(anchor: String? = nil) {
+    let query = anchor.map { "?\($0)" } ?? ""
+    let urls = [
+      "x-apple.systempreferences:com.apple.preference.security\(query)",
+      "x-apple.systempreferences:com.apple.preference.security",
+    ]
+
+    for urlString in urls {
+      if let url = URL(string: urlString), NSWorkspace.shared.open(url) {
+        return
+      }
+    }
+
+    let settingsApp = URL(fileURLWithPath: "/System/Applications/System Settings.app")
+    NSWorkspace.shared.openApplication(
+      at: settingsApp,
+      configuration: NSWorkspace.OpenConfiguration()
+    )
+  }
+}
+
 struct OnboardingPermissionsStep: View {
   @Binding var isAccessibilityGranted: Bool
   @Binding var isScreenRecordingGranted: Bool
@@ -118,12 +141,7 @@ struct OnboardingPermissionsStep: View {
         Spacer()
 
         Button("Open Privacy & Security") {
-          if let url = URL(
-            string:
-              "x-apple.systemsettings:com.apple.settings.PrivacySecurity.extension"
-          ) {
-            NSWorkspace.shared.open(url)
-          }
+          SystemSettingsOpener.openPrivacyPane()
         }
         .buttonStyle(.link)
         .accessibilityLabel("Open Privacy and Security settings")
@@ -144,12 +162,7 @@ struct OnboardingPermissionsHelper {
 
     Task { @MainActor in
       try? await Task.sleep(for: .milliseconds(200))
-      if let url = URL(
-        string:
-          "x-apple.systemsettings:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility"
-      ) {
-        NSWorkspace.shared.open(url)
-      }
+      SystemSettingsOpener.openPrivacyPane(anchor: "Privacy_Accessibility")
     }
   }
 

--- a/macOS/WritingTools/Views/Onboarding/Views/OnboardingPermissionsStep.swift
+++ b/macOS/WritingTools/Views/Onboarding/Views/OnboardingPermissionsStep.swift
@@ -13,8 +13,11 @@ enum SystemSettingsOpener {
   @MainActor
   static func openPrivacyPane(anchor: String? = nil) {
     let query = anchor.map { "?\($0)" } ?? ""
+    // System Settings still registers the x-apple.systempreferences URL scheme.
     let urls = [
+      "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension\(query)",
       "x-apple.systempreferences:com.apple.preference.security\(query)",
+      "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension",
       "x-apple.systempreferences:com.apple.preference.security",
     ]
 


### PR DESCRIPTION
## Background
This PR is specific to the macOS app under `macOS/WritingTools`. Other platform implementations live in separate codebases and are not affected.

The macOS app currently opens Privacy & Security settings with URLs using the `x-apple.systemsettings` scheme, for example:

```text
x-apple.systemsettings:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility
```

On macOS 26.4 (`25E246`), that scheme has no registered handler, which causes macOS to show:

```text
There is no application set to open the URL ...
```

This appears to be a regression introduced by switching from the old `x-apple.systempreferences` scheme to `x-apple.systemsettings`. Although Apple's settings app is now named System Settings, its bundle identifier and URL scheme still use the older System Preferences naming.

## Investigation
I checked the local System Settings app metadata on macOS 26.4:

- `/System/Applications/System Settings.app` has bundle identifier `com.apple.systempreferences`.
- Its `CFBundleURLTypes` advertise `x-apple.systempreferences`.
- It does not advertise `x-apple.systemsettings`.

I also checked Launch Services through `NSWorkspace.urlForApplication(toOpen:)`:

- `x-apple.systemsettings:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility` resolves to no handler.
- `x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility` resolves to `/System/Applications/System Settings.app`.
- `x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility` also resolves to `/System/Applications/System Settings.app`.

The Privacy & Security settings extension is still present as `com.apple.settings.PrivacySecurity.extension`, and its metadata includes `allowsXAppleSystemPreferencesURLScheme = 1` plus legacy bundle identifier `com.apple.preference.security`. So the current extension identifier is valid, but it still needs to be opened through the `x-apple.systempreferences` scheme.

Repository history shows the current upstream `x-apple.systemsettings` URLs were introduced in commit `460f53f`, replacing previously used `x-apple.systempreferences:com.apple.preference.security...` URLs.

## Summary
- Replace the unsupported `x-apple.systemsettings` scheme with the `x-apple.systempreferences` scheme that System Settings actually registers.
- Try the current Privacy & Security extension identifier first.
- Fall back to the legacy Security preference pane identifier.
- Fall back to opening System Settings directly if deep linking fails.
- Refresh onboarding permission status when the macOS app becomes active again after the user returns from System Settings.

## Testing
- Verified URL handler resolution locally on macOS 26.4 with `NSWorkspace.urlForApplication(toOpen:)`.
- Verified the System Settings app bundle metadata locally: bundle identifier `com.apple.systempreferences`; registered scheme `x-apple.systempreferences`.
- Built the PR branch successfully with `xcodebuild -project macOS/WritingTools.xcodeproj -scheme WritingTools -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build`.