### PR TITLE
Allow empty API keys for custom OpenAI endpoints in the macOS app

### DIFF
--- a/macOS/WritingTools/Models/Providers/OpenAIProvider.swift
+++ b/macOS/WritingTools/Models/Providers/OpenAIProvider.swift
@@ -44,13 +44,13 @@ final class OpenAIProvider: AIProvider {
             isProcessing = false
         }
 
-        guard !config.apiKey.isEmpty else {
-            throw NSError(domain: "OpenAIAPI", code: -1, userInfo: [NSLocalizedDescriptionKey: "API key is missing."])
-        }
-
         // Check for custom Base URL
         if !config.baseURL.isEmpty && config.baseURL != OpenAIConfig.defaultBaseURL {
             return try await Self.performCustomOpenAIRequest(config: config, systemPrompt: systemPrompt, userPrompt: userPrompt, images: images)
+        }
+
+        guard !config.apiKey.isEmpty else {
+            throw NSError(domain: "OpenAIAPI", code: -1, userInfo: [NSLocalizedDescriptionKey: "API key is missing."])
         }
 
         let baseURL = config.baseURL.isEmpty ? OpenAIConfig.defaultBaseURL : config.baseURL
@@ -141,7 +141,9 @@ final class OpenAIProvider: AIProvider {
         
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        if !config.apiKey.isEmpty {
+            request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 60
         
@@ -236,7 +238,9 @@ final class OpenAIProvider: AIProvider {
         
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        if !config.apiKey.isEmpty {
+            request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 60
         
@@ -318,10 +322,6 @@ final class OpenAIProvider: AIProvider {
             activeTask = nil
         }
         
-        guard !config.apiKey.isEmpty else {
-            throw NSError(domain: "OpenAIAPI", code: -1, userInfo: [NSLocalizedDescriptionKey: "API key is missing."])
-        }
-        
         // For custom base URLs, use manual SSE streaming
         if !config.baseURL.isEmpty && config.baseURL != OpenAIConfig.defaultBaseURL {
             let config = self.config
@@ -337,6 +337,10 @@ final class OpenAIProvider: AIProvider {
             activeTask = streamTask
             try await streamTask.value
             return
+        }
+
+        guard !config.apiKey.isEmpty else {
+            throw NSError(domain: "OpenAIAPI", code: -1, userInfo: [NSLocalizedDescriptionKey: "API key is missing."])
         }
         
         let baseURL = config.baseURL.isEmpty ? OpenAIConfig.defaultBaseURL : config.baseURL

--- a/macOS/WritingTools/Views/Settings/SettingsView.swift
+++ b/macOS/WritingTools/Views/Settings/SettingsView.swift
@@ -260,7 +260,10 @@ struct SettingsView: View {
                 return "Custom OpenRouter model name is required."
             }
         case "openai":
-            if settings.openAIApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let trimmedOpenAIBaseURL = settings.openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+            let isUsingDefaultOpenAIEndpoint = trimmedOpenAIBaseURL.isEmpty || trimmedOpenAIBaseURL == OpenAIConfig.defaultBaseURL
+            if isUsingDefaultOpenAIEndpoint &&
+                settings.openAIApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 return "OpenAI API key is required."
             }
             if settings.openAIModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {


### PR DESCRIPTION
## Background
This PR is specific to the macOS app under `macOS/WritingTools`. Other platform implementations live in separate codebases and are not affected.

I use LM Studio as a local LLM backend for the macOS app. LM Studio exposes an OpenAI-compatible API, so the macOS app's OpenAI-compatible provider can call it by setting a custom base URL such as a local `localhost` endpoint.

In this local-provider scenario, an API key is not required. Requiring the API key field to be non-empty prevents otherwise valid OpenAI-compatible local endpoints from working in the macOS app.

## Summary
- Allow the macOS app's OpenAI-compatible provider to use custom base URLs without requiring an API key.
- Omit the `Authorization` header for custom OpenAI-compatible requests when the API key field is empty.
- Continue requiring an API key when the default OpenAI endpoint is used.

## Testing
- Verified in a local signed macOS build with an LM Studio-compatible local endpoint and an empty API key field.
- Confirmed the combined local branch still builds successfully with `xcodebuild -project macOS/WritingTools.xcodeproj -scheme WritingTools -configuration Release -destination 'platform=macOS'`.